### PR TITLE
Allow urlXmlConfiguration to be set

### DIFF
--- a/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
+++ b/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
@@ -28,10 +28,7 @@ namespace Uol.PagSeguro.Resources
     public static class PagSeguroConfiguration
     {
         //PagSeguro .NET Library Tests
-        private const string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
-
-        //Website
-        //private static string urlXmlConfiguration = HttpRuntime.AppDomainAppPath + "PagSeguroConfig.xml";
+        private string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
 
         private static string _moduleVersion;
         private static string _cmsVersion;
@@ -52,6 +49,10 @@ namespace Uol.PagSeguro.Resources
             get
             {
                 return urlXmlConfiguration;
+            }
+            set
+            {
+                urlXmlConfiguration = value;
             }
         }
 


### PR DESCRIPTION
Using a default hard-coded URL in the demo project and NuGet package isn't very handy. This change allows for the `urlXmlConfiguration` property to be set at runtime.