### PR TITLE
Adiciona local configurável para o PagSeguroConfig

### DIFF
--- a/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
+++ b/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
@@ -28,7 +28,7 @@ namespace Uol.PagSeguro.Resources
     public static class PagSeguroConfiguration
     {
         //PagSeguro .NET Library Tests
-        private const string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
+        private string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
 
         //Website
         //private static string urlXmlConfiguration = HttpRuntime.AppDomainAppPath + "PagSeguroConfig.xml";
@@ -52,6 +52,10 @@ namespace Uol.PagSeguro.Resources
             get
             {
                 return urlXmlConfiguration;
+            }
+            set
+            {
+                urlXmlConfiguration = value;
             }
         }
 

--- a/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
+++ b/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
@@ -28,7 +28,7 @@ namespace Uol.PagSeguro.Resources
     public static class PagSeguroConfiguration
     {
         //PagSeguro .NET Library Tests
-        private string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
+        private static string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
 
         //Website
         //private static string urlXmlConfiguration = HttpRuntime.AppDomainAppPath + "PagSeguroConfig.xml";


### PR DESCRIPTION
A localização do arquivo PagSeguroConfig.xml precisa ser configurável, caso contrário é inútil adicionar a biblioteca ao nuget, e torna muito difícil fazer debug em máquina local. Por exemplo, como ele usa ".../..." em micro local o ISS express está no C:, então se você tem vários projetos a testar, em outra partição, precisa todas as vezes copiar o arquivo xml para c:\Configurations. Usando um site no Azure, onde a estrutura do ".../..." é diferente, caixa erros em alguns projetos.